### PR TITLE
Problem: Subspace does not work with ansible 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-ansible>=2.3.0.0
+git+https://github.com/ansible/ansible.git@v2.4.2.0-0.3.beta3#egg=ansible
+# ansible==2.4.2.0
 redis>=2.10.3

--- a/subspace/internal/executor.py
+++ b/subspace/internal/executor.py
@@ -2,21 +2,23 @@ from ansible.executor import playbook_executor
 from ansible.utils.ssh_functions import check_for_controlpersist
 from ansible import constants as C
 
-from subspace.task_queue_manager import SubspaceTaskQueueManager
+from subspace.internal.task_queue_manager import SubspaceTaskQueueManager
 
-class PlaybookExecutor(playbook_executor.PlaybookExecutor):
+
+class SubspacePlaybookExecutor(playbook_executor.PlaybookExecutor):
     '''
-    This is an extension of ansible playbook_excutor.PlaybookExecutor
-    Its sole purpose is to provide the ability to pass a *custom* TaskQueueManager.
+    The SubspacePlaybookExecutor works identically to the PlaybookExecutor defined by ansible,
+    *WITH ONE EXCEPTION:*
+      - Override the default `task_queue_manager` to be SubspaceTaskQueueManager
     '''
 
     def __init__(self, playbooks, inventory, variable_manager, loader, options, passwords):
-        self._playbooks        = playbooks
-        self._inventory        = inventory
+        self._playbooks = playbooks
+        self._inventory = inventory
         self._variable_manager = variable_manager
-        self._loader           = loader
-        self._options          = options
-        self.passwords         = passwords
+        self._loader = loader
+        self._options = options
+        self.passwords = passwords
         self._unreachable_hosts = dict()
 
         if options.listhosts or options.listtasks or options.listtags or options.syntax:

--- a/subspace/internal/executor.py
+++ b/subspace/internal/executor.py
@@ -2,7 +2,7 @@ from ansible.executor import playbook_executor
 from ansible.utils.ssh_functions import check_for_controlpersist
 from ansible import constants as C
 
-from subspace.internal.task_queue_manager import SubspaceTaskQueueManager
+from .task_queue_manager import SubspaceTaskQueueManager
 
 
 class SubspacePlaybookExecutor(playbook_executor.PlaybookExecutor):

--- a/subspace/internal/playbook.py
+++ b/subspace/internal/playbook.py
@@ -1,0 +1,142 @@
+import logging
+import os
+import operator
+import json
+
+from ansible.cli.playbook import PlaybookCLI
+
+from .playbook_options import PythonPlaybookOptions
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+default_logger = logging.getLogger(__name__)
+
+
+class PythonPlaybookRunner(PlaybookCLI):
+    """
+    Overwrite key methods from 'ansible.cli.playbook.PlaybookCLI'
+    - Remove all reliance on the actual _cli_ portion.
+      - Gather options via PythonPlaybookOptions
+    """
+
+    inventory = None
+    loader = None
+    options = None
+    extra_vars = None
+    variable_manager = None
+
+    @staticmethod
+    def _convert_extra_vars_to_option(extra_vars_dict={}):
+        """
+        Because we are 'mocking a CLI', we need to convert:
+        {...} --> ['{...}']
+
+        This will allow `_play_prereqs` to handle the code
+        as it would if passed from the command-line.
+        After `_play_prereqs` has parsed the JSON/YAML option,
+        `variable_manager.extra_args` will again return the {...} structure.
+        """
+        extra_vars_option = [json.dumps(extra_vars_dict)]
+        return extra_vars_option
+
+    @classmethod
+    def _select_playbooks_from_path(cls, playbook_path, limit_playbooks=[]):
+        """
+        Input:
+          - Path of playbooks directory
+          - A list of playbooks to be run.
+        Output:
+          An ordered list of playbook files.
+        """
+        if not isinstance(playbook_path, basestring):
+            raise TypeError(
+                "Expected 'playbook_path' as string,"
+                " received %s" % type(playbook_path))
+        # Convert file path to list of playbooks:
+        if not os.path.exists(playbook_path):
+            raise ValueError("Could not find path: %s" % (playbook_path,))
+
+        if os.path.isdir(playbook_path):
+            playbook_list = cls._select_playbooks_from_dir(
+                playbook_path, limit_playbooks)
+        else:
+            playbook_list = [playbook_path]
+        return playbook_list
+
+    @classmethod
+    def _select_playbooks_from_dir(cls, playbook_dir, limit=[]):
+        """
+        Given a directory, return all `.yml` playbooks
+        If a limit is specified, only include playbooks found in the limit.
+        """
+        return [playbook_path for playbook_path in cls._list_yml_files_in_dir(playbook_dir)
+                if not limit or playbook_path.split('/')[-1] in limit]
+
+    @classmethod
+    def _list_yml_files_in_dir(cls, directory):
+        """
+        Walk the directory and retrieve each yml file.
+        """
+        files = []
+        directories = list(os.walk(directory))
+        directories.sort(cmp=operator.lt)
+        for d in directories:
+            a_dir = d[0]
+            files_in_dir = d[2]
+            files_in_dir.sort()
+            if os.path.isdir(a_dir):
+                for f in files_in_dir:
+                    if os.path.splitext(f)[1] == ".yml":
+                        files.append(os.path.join(a_dir, f))
+        return files
+
+    @classmethod
+    def factory(
+            cls, playbook_path, limit_playbooks=[],
+            **runner_options):
+        """
+        This factory method can help select an arbitrary number of playbooks to be executed,
+        without having to explicitly state each one.
+        By default, all playbooks found in `playbook_path` will be executed.
+        If `limit_playbooks` is passed, only those playbooks will be executed.
+
+        Notes: * Playbook files are identified as ending in .yml
+               * Playbooks are not executed until you have called SubspacePlaybookRunner.run()
+        """
+        playbooks = cls._select_playbooks_from_path(playbook_path, limit_playbooks)
+        playbook_runner = cls(
+            playbooks,
+            **runner_options
+        )
+        return playbook_runner
+
+
+    def __init__(self, args, callback=None, extra_vars={}, **parser_kwargs):
+        """
+        This custom method drops the dependency for 'options'
+        Instead, PythonPlaybookOptions will read the kwargs and
+        select sensible defaults when possible.
+
+        This allows us to take advantage for pure-python calls.
+        """
+        self.args = args
+        self.action = None
+        self.callback = callback
+
+        #This hack is required to properly map dict --> options.extra_vars
+        if type(extra_vars) == dict:
+            extra_vars = PythonPlaybookRunner._convert_extra_vars_to_option(extra_vars)
+        parser_kwargs['extra_vars'] = extra_vars
+
+        self.parser = PythonPlaybookOptions(
+            args=args,
+            **parser_kwargs
+        )
+        self.options = self.parser
+
+
+

--- a/subspace/internal/playbook_options.py
+++ b/subspace/internal/playbook_options.py
@@ -1,0 +1,129 @@
+import logging
+from ansible import constants as C
+from ansible.cli import InvalidOptsParser
+
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
+
+default_logger = logging.getLogger(__name__)
+
+
+class PythonPlaybookOptions(InvalidOptsParser):
+    """
+    PythonPlaybookOptions class is used to replace
+    human-interaction and argparse, when creating a
+    PythonPlaybookRunner()
+
+    As settings are added/removed in ansible, you may need
+    to change the acceptable kwargs passed to PythonPlaybookOptions
+    """
+    version = "subspace-1.0"
+    usage = "This strategy is not meant to be used from the CLI.",
+    desc = "Instead, call subspace from the Python REPL by using the command(s): ...",
+
+    def __str__(self):
+        options = self.__dict__
+        return str(options)
+
+    def __repr__(self):
+        return self.__str__()
+
+    def get_version(self):
+        return self.version
+
+    def __init__(
+        self, verbosity=0, inventory=None, config_file=None, listhosts=None, subset=None, module_paths=None, extra_vars=[],
+        forks=None, ask_vault_pass=False, vault_password_files=[], new_vault_password_files=[], vault_ids=[],
+        output_file=None, tags=[], skip_tags=[], one_line=None, tree=None, ask_sudo_pass=False, ask_su_pass=False,
+        sudo=False, sudo_user=None, become=False, become_method='sudo', su_user=None, become_ask_pass=False, become_pass=None,
+        ask_pass=False, private_key_file=None, remote_user='root', connection='smart', conn_pass=None, timeout=None, ssh_common_args='',
+        sftp_extra_args=None, scp_extra_args=None, ssh_extra_args='', poll_interval=None, seconds=None, check=False,
+        syntax=None, diff=False, force_handlers=False, flush_cache=False, listtasks=None, listtags=None, module_path=None,
+        # Subspace arguments below this line
+        logger=None, additional_args=None, **additional_kwargs):
+
+        # Use ansible constants to set sensible defaults
+        # This will search the PATH and set values accordingly
+        # based on first ansible.cfg file found in PATH
+        if not inventory:
+            inventory = C.DEFAULT_HOST_LIST
+        if not su_user:
+            su_user = C.DEFAULT_BECOME_USER
+        if not become:
+            become = C.DEFAULT_SU
+        if not subset:
+            subset = C.DEFAULT_SUBSET
+        if not forks:
+            forks = C.DEFAULT_FORKS
+        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+        if vault_ids:
+            vault_ids = default_vault_ids + vault_ids
+        else:
+            vault_ids = default_vault_ids
+        # Flags (These will never be set, but options requires these variables to function as a standalone replacement.)
+        self.listhosts = listhosts
+        self.listtasks = listtasks
+        self.listtags = listtags
+        self.syntax = syntax
+        # Options that will be set often
+        self.verbosity = verbosity
+        self.config_file = config_file
+        self.inventory = inventory
+        self.subset = subset
+        self.module_paths = module_paths
+        self.extra_vars = extra_vars
+        # Options that will be set less often
+        self.forks = forks
+        self.vault_ids = vault_ids
+        self.ask_vault_pass = ask_vault_pass
+        self.vault_password_files = vault_password_files
+        self.new_vault_password_files = new_vault_password_files
+        self.output_file = output_file
+        self.tags = tags
+        self.skip_tags = skip_tags
+        self.one_line = one_line
+        self.tree = tree
+        self.ask_sudo_pass = ask_sudo_pass
+        self.ask_su_pass = ask_su_pass
+        self.sudo = sudo
+        self.sudo_user = sudo_user
+        self.su = become  # Remove when  ansible==2.5
+        self.become = become
+        self.become_method = become_method
+        self.become_user = su_user
+        self.su_user = su_user
+        self.become_pass = become_pass
+        self.become_ask_pass = become_ask_pass
+        self.ask_pass = ask_pass
+        self.private_key_file = private_key_file
+        self.remote_user = remote_user
+        self.connection = connection
+        self.conn_pass = conn_pass
+        self.timeout = timeout
+        self.ssh_common_args = ssh_common_args
+        self.sftp_extra_args = sftp_extra_args
+        self.scp_extra_args = scp_extra_args
+        self.ssh_extra_args = ssh_extra_args
+        self.poll_interval = poll_interval
+        self.seconds = seconds
+        self.check = check
+        self.diff = diff
+        self.force_handlers = force_handlers
+        self.flush_cache = flush_cache
+        self.module_path = module_path
+        # SUBSPACE-specific options below this line
+        if not logger:
+            logger = default_logger
+
+        self.logger = logger
+        if additional_args:
+            self.logger.warn(
+                "The following additional_args passed to runner were ignored: %s" % additional_args)
+            self.ignored_args = additional_args
+        if additional_kwargs:
+            self.logger.warn(
+                "The following kwargs passed to options were ignored: %s" % additional_kwargs)
+            self.ignored_kwargs = additional_kwargs

--- a/subspace/runner.py
+++ b/subspace/runner.py
@@ -1,35 +1,37 @@
-import os
-import stat
-import operator
-
 import logging
+import os
+import operator
+import stat
+import json
 
-from ansible.inventory import Inventory
-from ansible.vars import VariableManager
+from ansible import constants as C
+from ansible.cli import InvalidOptsParser
 from ansible.cli.playbook import CLI, PlaybookCLI
-from ansible.utils.vars import load_options_vars
-from ansible.parsing.dataloader import DataLoader
+from ansible.errors import AnsibleError, AnsibleOptionsError
 from ansible.playbook.block import Block
 from ansible.playbook.play_context import PlayContext
-from ansible.utils.vars import load_extra_vars
-from ansible import constants as C
-
-from ansible.utils.display import Display
-from ansible.errors import AnsibleError
 
 from subspace.exceptions import NoValidHosts
-from subspace.executor import PlaybookExecutor
+from subspace.internal.executor import SubspacePlaybookExecutor
 from subspace.stats import SubspaceAggregateStats
 
-display = Display()
+try:
+    from __main__ import display
+except ImportError:
+    from ansible.utils.display import Display
+    display = Display()
 
 default_logger = logging.getLogger(__name__)
 
 
-class RunnerOptions(object):
+class SubspaceOptParser(InvalidOptsParser):
     """
-    RunnerOptions class is used to replace Ansible OptParser
+    (Formerly RunnerOptions)
+    SubspaceOptParser class is used to replace Ansible OptParser
     """
+    version = "subspace-1.0"
+    usage="This strategy is not meant to be used from the CLI.",
+    desc="Instead, call subspace from the Python REPL by using the command(s): ...",
 
     def __str__(self):
         options = self.__dict__
@@ -38,41 +40,58 @@ class RunnerOptions(object):
     def __repr__(self):
         return self.__str__()
 
+    def get_version(self):
+        return self.version
+
     def __init__(
-        self, verbosity=0, inventory=None, listhosts=None, subset=None, module_paths=None, extra_vars=[],
-        forks=None, ask_vault_pass=False, vault_password_file=None, new_vault_password_file=None,
+        self, verbosity=0, inventory=None, config_file=None, listhosts=None, subset=None, module_paths=None, extra_vars=[],
+        forks=None, ask_vault_pass=False, vault_password_files=[], new_vault_password_files=[], vault_ids=[],
         output_file=None, tags=[], skip_tags=[], one_line=None, tree=None, ask_sudo_pass=False, ask_su_pass=False,
-        sudo=False, sudo_user=None, become=False, become_method=None, become_user=None, become_ask_pass=False,
+        sudo=False, sudo_user=None, become=False, become_method=None, su_user=None, become_ask_pass=False,
         ask_pass=False, private_key_file=None, remote_user='root', connection=None, timeout=None, ssh_common_args='',
         sftp_extra_args=None, scp_extra_args=None, ssh_extra_args='', poll_interval=None, seconds=None, check=False,
-        syntax=None, diff=False, force_handlers=False, flush_cache=True, listtasks=None, listtags=None, module_path=None, su=None,
-        logger=None):
+        syntax=None, diff=False, force_handlers=False, flush_cache=False, listtasks=None, listtags=None, module_path=None,
+        # Subspace arguments below this line
+        logger=None, args=None, **additional_kwargs):
         # Dynamic sensible defaults
+        if not inventory:
+            inventory = C.DEFAULT_HOST_LIST
         if not logger:
             logger = default_logger
         if not connection:
             connection = 'smart'
         if not become_method:
             become_method = 'sudo'
-        if not become_user:
-            become_user = 'root'
-        if not su:
-            su = C.DEFAULT_SU
+        if not su_user:
+            su_user = C.DEFAULT_BECOME_USER
+        if not become:
+            become = C.DEFAULT_SU
         if not subset:
             subset = C.DEFAULT_SUBSET
         if not forks:
             forks = C.DEFAULT_FORKS
+        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
+        if vault_ids:
+            vault_ids = default_vault_ids + vault_ids
+        else:
+            vault_ids = default_vault_ids
+        # Flags
+        self.listhosts = listhosts
+        self.listtasks = listtasks
+        self.listtags = listtags
+        self.syntax = syntax
         # Set your options
         self.verbosity = verbosity
+        self.config_file = config_file
         self.inventory = inventory
-        self.listhosts = listhosts
         self.subset = subset
         self.module_paths = module_paths
         self.extra_vars = extra_vars
         self.forks = forks
+        self.vault_ids = vault_ids
         self.ask_vault_pass = ask_vault_pass
-        self.vault_password_file = vault_password_file
-        self.new_vault_password_file = new_vault_password_file
+        self.vault_password_files = vault_password_files
+        self.new_vault_password_files = new_vault_password_files
         self.output_file = output_file
         self.tags = tags
         self.skip_tags = skip_tags
@@ -80,12 +99,13 @@ class RunnerOptions(object):
         self.tree = tree
         self.ask_sudo_pass = ask_sudo_pass
         self.ask_su_pass = ask_su_pass
-        self.su = su
         self.sudo = sudo
         self.sudo_user = sudo_user
+        self.su = become  # Remove when  ansible==2.5
         self.become = become
         self.become_method = become_method
-        self.become_user = become_user
+        self.become_user = su_user
+        self.su_user = su_user
         self.become_ask_pass = become_ask_pass
         self.ask_pass = ask_pass
         self.private_key_file = private_key_file
@@ -99,107 +119,76 @@ class RunnerOptions(object):
         self.poll_interval = poll_interval
         self.seconds = seconds
         self.check = check
-        self.syntax = syntax
         self.diff = diff
         self.force_handlers = force_handlers
         self.flush_cache = flush_cache
-        self.listtasks = listtasks
-        self.listtags = listtags
         self.module_path = module_path
+        # SUBSPACE-specific options below this line
         self.logger = logger
+        if args and self.logger:
+            self.logger.warn(
+                "The following args passed to runner were ignored: %s" % args)
+        if additional_kwargs and self.logger:
+            self.logger.warn(
+                "The following kwargs passed to options were ignored: %s" % additional_kwargs)
+            self.ignored_kwargs = additional_kwargs
+
 
 
 class PlaybookShell(PlaybookCLI):
     """
-    PlaybookShell uses RunnerOptions to replace 'args'
-    To create a PlaybookShell:
-        runner_opts = {'verbosity':4}
-        Runner.factory(
-            host_file,
-            os.path.join(playbook_dir, playbook_path),  # Also takes a playbook directory for list-of-files.
-            extra_vars=extra_vars,
-            limit_hosts='127.0.0.1',  # or IP/Hostname
-            limit_playbooks=['check_networking.yml'] ,  #filename relative to the playbook directory
-            private_key_file="/path/to/id_rsa",
-            **runner_opts)
+    Run ansible playbooks via python calls
     """
 
     inventory = None
     loader = None
     options = None
-    playbooks = None
     extra_vars = None
     variable_manager = None
 
-    @classmethod
-    def factory(cls, host_file, playbook_path, logger,
-                **runner_options):
+    def __init__(self, args, callback=None, **parser_kwargs):
         """
-        Walk the Directory structure and return an ordered list of
-        playbook objects.
+        This custom method drops the dependency for 'options'
+        Instead, SubspaceOptParser will read the kwargs and
+        select sensible defaults when possible.
 
-        :playbook_path: The directory/path to use for playbook list.
-        :runner_options: These keyword args will be passed into Runner
-
-        Notes: * Playbook files are identified as ending in .yml
-               * Playbooks are not executed until calling Runner.run()
+        This allows us to take advantage for pure-python calls.
         """
-
-        if 'extra_vars' in runner_options and 'extra_vars' not in runner_options:
-            logger.warn(
-                "WARNING: Use 'extra_vars' to pass extra_vars into the playbooks"
-            )
-            extra_vars = runner_options['extra_vars']
-        else:
-            extra_vars = runner_options.pop('extra_vars', {})
-
-        runner = Runner(
-            host_file,
-            playbook_path,
-            extra_vars=extra_vars,
-            logger=logger,
-            **runner_options
-        )
-        return runner
-
-    def __init__(self, hosts_file, playbook_path, extra_vars, private_key_file,
-                 limit_hosts=None, limit_playbooks=None,
-                 group_vars_map={}, logger=None,
-                 use_password=None, callback=None, **runner_opts_args):
-
+        self.args = args
+        self.parser = None
+        self.action = None
         self.callback = callback
-        self.extra_vars = extra_vars  # Override 'extra vars'
-        self.options = RunnerOptions(
-                private_key_file=private_key_file,
-                subset=limit_hosts,
-                inventory=hosts_file,
-                logger=logger,
-                **runner_opts_args
-            )
-
-        # NOTE: Playbooks is usually a path
-        # ex: deploy_playbooks/ _OR_ util_playbooks/check_networking.yml
-        # it could also be a list of playbooks to be executed.
-        self._set_playbooks(playbook_path, limit_playbooks)
-
-        # Become Pass Needed if not logging in as user root
-        if use_password:
-            passwords = {'become_pass': use_password}
-        else:
-            passwords = None
+        self.parser = SubspaceOptParser(
+            args=args,
+            **parser_kwargs
+        )
+        self.options = self.parser
+        # has already been computed by SubspaceOptParser, use it.
+        # REVIEWERS NOTE: 'use_password' was a parser_kwarg that used to do the following:
+        # # Become Pass Needed if not logging in as user root
+        # if use_password:
+        #     passwords = {'become_pass': use_password}
+        #     else:
+        #         passwords = None
+        # I will remove this prior to merge, if confirmed that this is not being used anywhere
+        # (I could not find it used anywhere) - SG
+        # END REVIEWERS NOTE
 
     def run(self):
+        """
+        Runs the ansible command
+        """
+        super(PlaybookCLI, self).run()
 
         # Note: slightly wrong, this is written so that implicit localhost
         # Manage passwords
-        sshpass    = None
-        becomepass    = None
-        b_vault_pass = None
+        sshpass = None
+        becomepass = None
         passwords = {}
 
         # initial error check, to make sure all specified playbooks are accessible
         # before we start running anything through the playbook executor
-        for playbook in self.playbooks:
+        for playbook in self.args:
             if not os.path.exists(playbook):
                 raise AnsibleError("the playbook: %s could not be found" % playbook)
             if not (os.path.isfile(playbook) or stat.S_ISFIFO(os.stat(playbook).st_mode)):
@@ -209,35 +198,10 @@ class PlaybookShell(PlaybookCLI):
         if not self.options.listhosts and not self.options.listtasks and not self.options.listtags and not self.options.syntax:
             self.normalize_become_options()
             (sshpass, becomepass) = self.ask_passwords()
-            passwords = { 'conn_pass': sshpass, 'become_pass': becomepass }
+            passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 
-        loader = DataLoader()
-
-        if self.options.vault_password_file:
-            # read vault_pass from a file
-            b_vault_pass = CLI.read_vault_password_file(self.options.vault_password_file, loader=loader)
-            loader.set_vault_password(b_vault_pass)
-        elif self.options.ask_vault_pass:
-            b_vault_pass = self.ask_vault_passwords()
-            loader.set_vault_password(b_vault_pass)
-        elif 'VAULT_PASS' in os.environ:
-            loader.set_vault_password(os.environ['VAULT_PASS'])
-
-        # create the variable manager, which will be shared throughout
-        # the code, ensuring a consistent view of global variables
-        variable_manager = VariableManager()
-
-        # Subspace injection
-        option_extra_vars = load_extra_vars(loader=loader, options=self.options)
-        option_extra_vars.update(self.extra_vars)
-        variable_manager.extra_vars = option_extra_vars
-        # End Subspace injection
-
-        variable_manager.options_vars = load_options_vars(self.options)
-
-        # create the inventory, and filter it based on the subset specified (if any)
-        inventory = Inventory(loader=loader, variable_manager=variable_manager, host_list=self.options.inventory)
-        variable_manager.set_inventory(inventory)
+        self.loader, self.inventory, self.variable_manager = self._play_prereqs(self.options)
+        loader, inventory, variable_manager = self.loader, self.inventory, self.variable_manager
 
         # (which is not returned in list_hosts()) is taken into account for
         # warning if inventory is empty.  But it can't be taken into account for
@@ -259,13 +223,12 @@ class PlaybookShell(PlaybookCLI):
         if self.options.flush_cache:
             self._flush_cache(inventory, variable_manager)
 
-        hosts = inventory.get_hosts()
-        if self.options.subset and not hosts:
-            raise NoValidHosts("The limit <%s> is not included in the inventory: %s" % (self.options.subset, inventory.host_list))
-       # create the playbook executor, which manages running the plays via a task queue manager
-        # Subspace injection
-        pbex = PlaybookExecutor(
-            playbooks=self.playbooks,
+        # create the playbook executor, which manages running the plays via a task queue manager
+        # pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options,
+        #                         passwords=passwords)
+        # BEGIN CUSTOM Subspace injection
+        pbex = SubspacePlaybookExecutor(
+            playbooks=self.args,
             inventory=inventory,
             variable_manager=variable_manager,
             loader=loader,
@@ -277,23 +240,19 @@ class PlaybookShell(PlaybookCLI):
         pbex._tqm.send_callback(
             'start_logging',
             logger=self.options.logger,
-            username=self.extra_vars.get('ATMOUSERNAME', "No-User"),
+            username=variable_manager.extra_vars.get('ATMOUSERNAME', "No-User"),
         )
-        for host in inventory._subset:
-            variables = inventory.get_vars(host)
-            self.options.logger.info(
-                "Vars found for hostname %s: %s" % (host, variables))
-        # End Subspace injection
+        # END CUSTOM Subspace injection
 
         results = pbex.run()
-        # Subspace injection
+        # BEGIN CUSTOM Subspace injection
         stats = pbex._tqm._stats
         self.stats = stats
         # Nonpersistent fact cache stores 'register' variables. We would like
         # to get access to stdout/stderr for specific commands and relay
         # some of that information back to the end user.
         self.results = dict(pbex._variable_manager._nonpersistent_fact_cache)
-        # End Subspace injection
+        # End CUSTOM Subspace injection
 
         if isinstance(results, list):
             for p in results:
@@ -345,7 +304,7 @@ class PlaybookShell(PlaybookCLI):
 
                             return taskmsg
 
-                        all_vars = variable_manager.get_vars(loader=loader, play=play)
+                        all_vars = variable_manager.get_vars(play=play)
                         play_context = PlayContext(play=play, options=self.options)
                         for block in play.compile():
                             block = block.filter_tagged_tasks(play_context, all_vars)
@@ -364,7 +323,53 @@ class PlaybookShell(PlaybookCLI):
         else:
             return results
 
-    def _set_playbooks(self, playbook_path, limit_playbooks):
+    # CUSTOM subspace functions below this line
+    def _get_playbook_name(self, playbook):
+        key_name = ''
+        with open(playbook,'r') as the_file:
+            for line in the_file.readlines():
+                if 'name:' in line.strip():
+                    # This is the name you will find in stats.
+                    key_name = line.replace('name:','').replace('- ','').strip()
+        if not key_name:
+            raise Exception(
+                "Unnamed playbooks will not allow CustomSubspaceStats to work properly.")
+        return key_name
+
+    def _get_playbook_map(self):
+        """
+        """
+        playbook_map = {
+            self._get_playbook_name(playbook): playbook
+            for playbook in self.args}
+        if len(playbook_map) != len(self.args):
+            raise ValueError("Non unique names in your playbooks will not allow CustomSubspaceStats to work properly. %s" % self.args)
+        return playbook_map
+
+
+# For compatability
+class Runner(PlaybookShell):
+
+    @staticmethod
+    def _convert_extra_vars_to_option(extra_vars_dict={}):
+        """
+        Because we are 'mocking a CLI', we need to convert:
+        {...} --> ['{...}']
+
+        This will allow `_play_prereqs` to handle the code
+        as it would if passed from the command-line.
+        After `_play_prereqs` has parsed the JSON/YAML option,
+        `variable_manager.extra_args` will again return the {...} structure.
+        """
+        extra_vars_option = [json.dumps(extra_vars_dict)]
+        return extra_vars_option
+
+    @classmethod
+    def _get_playbook_args(cls, playbook_path, limit_playbooks):
+        """
+        Walk the directory, return an ordered list of playbook objects.
+        If 'limit_playbooks' is included, only return matching playbooks within the directory.
+        """
         if not isinstance(playbook_path, basestring):
             raise TypeError(
                 "Expected 'playbook_path' as string,"
@@ -374,15 +379,14 @@ class PlaybookShell(PlaybookCLI):
             raise ValueError("Could not find path: %s" % (playbook_path,))
 
         if os.path.isdir(playbook_path):
-            playbook_list = self._get_playbook_files(
+            playbook_list = cls._get_playbook_files(
                 playbook_path, limit_playbooks)
         else:
             playbook_list = [playbook_path]
+        return playbook_list
 
-        self.playbooks = playbook_list
-        return self.playbooks
-
-    def _get_playbook_files(self, playbook_dir, limit=[]):
+    @classmethod
+    def _get_playbook_files(cls, playbook_dir, limit=[]):
         """
         Walk the Directory structure and return an ordered list of
         playbook objects.
@@ -390,10 +394,11 @@ class PlaybookShell(PlaybookCLI):
         :directory: The directory to walk and search for playbooks.
         Notes: * Playbook files are identified as ending in .yml
         """
-        return [pb for pb in self._get_files(playbook_dir)
+        return [pb for pb in cls._get_files(playbook_dir)
                 if not limit or pb.split('/')[-1] in limit]
 
-    def _get_files(self, directory):
+    @classmethod
+    def _get_files(cls, directory):
         """
         Walk the directory and retrieve each yml file.
         """
@@ -410,30 +415,30 @@ class PlaybookShell(PlaybookCLI):
                         files.append(os.path.join(a_dir, f))
         return files
 
-    def _get_playbook_name(self, playbook_path):
-        key_name = ''
-        plays = []
-        with open(playbook_path,'r') as the_file:
-            for line in the_file.readlines():
-                if 'name:' in line.strip():
-                    # This is the name you will find in stats.
-                    key_name = line.replace('name:','').replace('- ','').strip()
-                    plays.append(key_name)
-        if not plays:
-            raise Exception(
-                "Error found in %s: All plays should include a name for CustomSubspaceStats to work properly." % playbook_path)
-        return plays
-
-    def _map_plays_to_playbook_path(self):
+    @classmethod
+    def factory(
+            cls, playbook_path,
+            limit_hosts=None, limit_playbooks=None,
+            extra_vars={},
+            **runner_options):
         """
-        """
-        play_to_path_map = {}
-        for playbook_path in self.playbooks:
-            keys = self._get_playbook_name(playbook_path)
-            for key in keys:
-                play_to_path_map[key] = playbook_path
-        return play_to_path_map
+        Walk the Directory structure and return an ordered list of
+        playbook objects.
 
-# For compatability
-class Runner(PlaybookShell):
-    pass
+        :playbook_path: The directory/path to use for playbook list.
+        :runner_options: These keyword args will be passed into Runner
+
+        Notes: * Playbook files are identified as ending in .yml
+               * Playbooks are not executed until calling Runner.run()
+        """
+
+        extra_vars_option = cls._convert_extra_vars_to_option(extra_vars)
+
+        args = cls._get_playbook_args(playbook_path, limit_playbooks)
+        runner = Runner(
+            args,
+            playbook_dir=playbook_path,
+            extra_vars=extra_vars_option,
+            **runner_options
+        )
+        return runner

--- a/subspace/runner.py
+++ b/subspace/runner.py
@@ -1,18 +1,13 @@
-import logging
 import os
-import operator
 import stat
-import json
 
-from ansible import constants as C
-from ansible.cli import InvalidOptsParser
-from ansible.cli.playbook import CLI, PlaybookCLI
-from ansible.errors import AnsibleError, AnsibleOptionsError
+from ansible.errors import AnsibleError
+from ansible.cli.playbook import PlaybookCLI
 from ansible.playbook.block import Block
 from ansible.playbook.play_context import PlayContext
 
-from subspace.exceptions import NoValidHosts
 from subspace.internal.executor import SubspacePlaybookExecutor
+from subspace.internal.playbook import PythonPlaybookRunner
 from subspace.stats import SubspaceAggregateStats
 
 try:
@@ -21,162 +16,81 @@ except ImportError:
     from ansible.utils.display import Display
     display = Display()
 
-default_logger = logging.getLogger(__name__)
 
-
-class SubspaceOptParser(InvalidOptsParser):
+class SubspacePlaybookRunner(PythonPlaybookRunner):
     """
-    (Formerly RunnerOptions)
-    SubspaceOptParser class is used to replace Ansible OptParser
+    A SubspacePlaybookRunner is responsible for:
+    - Replace creation of playbook executor, with custom SubspacePlaybookExecutor, which manages running the plays via a custom task queue manager: SubspaceTaskQueueManager
+    - Ensuring that the default 'strategy' for all playbooks is Subspace (Handled by SubspaceTaskQueueManager)
+    - In addition to the properties included in PythonPlaybookRunner, a SubspacePlaybookRunner will include the following variables after a run():
+      - loader
+      - inventory
+      - variable_manager
+      - logger
+      - stats
+      - *results (AKA variable_manager._nonpersistent_fact_cache)
+    * = Nonpersistent fact cache stores 'register' variables, this will include the stdout/stderr/exit code for specific commands.
     """
-    version = "subspace-1.0"
-    usage="This strategy is not meant to be used from the CLI.",
-    desc="Instead, call subspace from the Python REPL by using the command(s): ...",
+    results = None
 
-    def __str__(self):
-        options = self.__dict__
-        return str(options)
+    def _store_playbook_results(self, playbook_executor):
+        # What we are storing
+        ansible_playbook_summary_stats = playbook_executor._tqm._stats
+        ansible_playbook_register_vars = playbook_executor._variable_manager._nonpersistent_fact_cache
 
-    def __repr__(self):
-        return self.__str__()
-
-    def get_version(self):
-        return self.version
-
-    def __init__(
-        self, verbosity=0, inventory=None, config_file=None, listhosts=None, subset=None, module_paths=None, extra_vars=[],
-        forks=None, ask_vault_pass=False, vault_password_files=[], new_vault_password_files=[], vault_ids=[],
-        output_file=None, tags=[], skip_tags=[], one_line=None, tree=None, ask_sudo_pass=False, ask_su_pass=False,
-        sudo=False, sudo_user=None, become=False, become_method=None, su_user=None, become_ask_pass=False,
-        ask_pass=False, private_key_file=None, remote_user='root', connection=None, timeout=None, ssh_common_args='',
-        sftp_extra_args=None, scp_extra_args=None, ssh_extra_args='', poll_interval=None, seconds=None, check=False,
-        syntax=None, diff=False, force_handlers=False, flush_cache=False, listtasks=None, listtags=None, module_path=None,
-        # Subspace arguments below this line
-        logger=None, args=None, **additional_kwargs):
-        # Dynamic sensible defaults
-        if not inventory:
-            inventory = C.DEFAULT_HOST_LIST
-        if not logger:
-            logger = default_logger
-        if not connection:
-            connection = 'smart'
-        if not become_method:
-            become_method = 'sudo'
-        if not su_user:
-            su_user = C.DEFAULT_BECOME_USER
-        if not become:
-            become = C.DEFAULT_SU
-        if not subset:
-            subset = C.DEFAULT_SUBSET
-        if not forks:
-            forks = C.DEFAULT_FORKS
-        default_vault_ids = C.DEFAULT_VAULT_IDENTITY_LIST
-        if vault_ids:
-            vault_ids = default_vault_ids + vault_ids
+        self.stats = ansible_playbook_summary_stats
+        if not self.results:
+            self.results = dict(ansible_playbook_register_vars)
         else:
-            vault_ids = default_vault_ids
-        # Flags
-        self.listhosts = listhosts
-        self.listtasks = listtasks
-        self.listtags = listtags
-        self.syntax = syntax
-        # Set your options
-        self.verbosity = verbosity
-        self.config_file = config_file
-        self.inventory = inventory
-        self.subset = subset
-        self.module_paths = module_paths
-        self.extra_vars = extra_vars
-        self.forks = forks
-        self.vault_ids = vault_ids
-        self.ask_vault_pass = ask_vault_pass
-        self.vault_password_files = vault_password_files
-        self.new_vault_password_files = new_vault_password_files
-        self.output_file = output_file
-        self.tags = tags
-        self.skip_tags = skip_tags
-        self.one_line = one_line
-        self.tree = tree
-        self.ask_sudo_pass = ask_sudo_pass
-        self.ask_su_pass = ask_su_pass
-        self.sudo = sudo
-        self.sudo_user = sudo_user
-        self.su = become  # Remove when  ansible==2.5
-        self.become = become
-        self.become_method = become_method
-        self.become_user = su_user
-        self.su_user = su_user
-        self.become_ask_pass = become_ask_pass
-        self.ask_pass = ask_pass
-        self.private_key_file = private_key_file
-        self.remote_user = remote_user
-        self.connection = connection
-        self.timeout = timeout
-        self.ssh_common_args = ssh_common_args
-        self.sftp_extra_args = sftp_extra_args
-        self.scp_extra_args = scp_extra_args
-        self.ssh_extra_args = ssh_extra_args
-        self.poll_interval = poll_interval
-        self.seconds = seconds
-        self.check = check
-        self.diff = diff
-        self.force_handlers = force_handlers
-        self.flush_cache = flush_cache
-        self.module_path = module_path
-        # SUBSPACE-specific options below this line
-        self.logger = logger
-        if args and self.logger:
-            self.logger.warn(
-                "The following args passed to runner were ignored: %s" % args)
-        if additional_kwargs and self.logger:
-            self.logger.warn(
-                "The following kwargs passed to options were ignored: %s" % additional_kwargs)
-            self.ignored_kwargs = additional_kwargs
+            self.results.update(dict(ansible_playbook_register_vars))
+        return
 
+    # def _get_playbook_map(self):
+    #         """
+    #         """
+    #         play_to_path_map = {}
+    #         for playbook_path in self.args:
+    #             keys = self._get_playbook_name(playbook_path)
+    #             for key in keys:
+    #                 play_to_path_map[key] = playbook_path
+    #         return play_to_path_map
 
+    def _get_playbook_name(self, playbook):
+        key_name = ''
+        with open(playbook, 'r') as the_file:
+            for line in the_file.readlines():
+                if 'name:' in line.strip():
+                    # This is the name you will find in stats.
+                    key_name = line.replace('name:', '').replace('- ', '').strip()
+        if not key_name:
+            raise Exception(
+                "Unnamed playbooks will not allow CustomSubspaceStats to work properly.")
+        return key_name
 
-class PlaybookShell(PlaybookCLI):
-    """
-    Run ansible playbooks via python calls
-    """
-
-    inventory = None
-    loader = None
-    options = None
-    extra_vars = None
-    variable_manager = None
-
-    def __init__(self, args, callback=None, **parser_kwargs):
+    def _get_playbook_map(self):
         """
-        This custom method drops the dependency for 'options'
-        Instead, SubspaceOptParser will read the kwargs and
-        select sensible defaults when possible.
-
-        This allows us to take advantage for pure-python calls.
         """
-        self.args = args
-        self.parser = None
-        self.action = None
-        self.callback = callback
-        self.parser = SubspaceOptParser(
-            args=args,
-            **parser_kwargs
-        )
-        self.options = self.parser
-        # has already been computed by SubspaceOptParser, use it.
-        # REVIEWERS NOTE: 'use_password' was a parser_kwarg that used to do the following:
-        # # Become Pass Needed if not logging in as user root
-        # if use_password:
-        #     passwords = {'become_pass': use_password}
-        #     else:
-        #         passwords = None
-        # I will remove this prior to merge, if confirmed that this is not being used anywhere
-        # (I could not find it used anywhere) - SG
-        # END REVIEWERS NOTE
+        playbook_map = {
+            self._get_playbook_name(playbook): playbook
+            for playbook in self.args}
+        if len(playbook_map) != len(self.args):
+            raise ValueError(
+                "Non-unique names in your playbooks will not allow "
+                "CustomSubspaceStats to work properly. %s" % self.args)
+        return playbook_map
 
     def run(self):
         """
-        Runs the ansible command
+        Runs the ansible command.
+
+        NOTE: This is a _direct copy_ of ansible/cli/playbook.PlaybookCLI
+              run() method
+              Changes made by subspace are clearly wrapped with the following lines:
+              ```
+              # BEGIN CUSTOM Subspace injection
+              ... code that was changed...
+              # END CUSTOM Subspace injection
+              ```
         """
         super(PlaybookCLI, self).run()
 
@@ -200,9 +114,7 @@ class PlaybookShell(PlaybookCLI):
             (sshpass, becomepass) = self.ask_passwords()
             passwords = {'conn_pass': sshpass, 'become_pass': becomepass}
 
-        self.loader, self.inventory, self.variable_manager = self._play_prereqs(self.options)
-        loader, inventory, variable_manager = self.loader, self.inventory, self.variable_manager
-
+        loader, inventory, variable_manager = self._play_prereqs(self.options)
         # (which is not returned in list_hosts()) is taken into account for
         # warning if inventory is empty.  But it can't be taken into account for
         # checking if limit doesn't match any hosts.  Instead we don't worry about
@@ -223,10 +135,17 @@ class PlaybookShell(PlaybookCLI):
         if self.options.flush_cache:
             self._flush_cache(inventory, variable_manager)
 
-        # create the playbook executor, which manages running the plays via a task queue manager
-        # pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options,
-        #                         passwords=passwords)
-        # BEGIN CUSTOM Subspace injection
+        # BEGIN CUSTOM Subspace injection -- Pre-playbook execution hook
+        # - Use the SubspacePlaybookExecutor instead of PlaybookExecutor
+        # - Store loader, inventory, and variable_manager for inspection after execution.
+        # - Initialize custom logger
+
+        #### create the playbook executor, which manages running the plays via a task queue manager
+        ### pbex = PlaybookExecutor(playbooks=self.args, inventory=inventory, variable_manager=variable_manager, loader=loader, options=self.options,
+
+        (self.loader, self.inventory, self.variable_manager) = (
+                loader, inventory, variable_manager)
+
         pbex = SubspacePlaybookExecutor(
             playbooks=self.args,
             inventory=inventory,
@@ -234,24 +153,23 @@ class PlaybookShell(PlaybookCLI):
             loader=loader,
             options=self.options,
             passwords=passwords)
-        play_to_path_map = self._map_plays_to_playbook_path()
+        play_to_path_map = self._get_playbook_map()
+
         pbex._tqm._stats = SubspaceAggregateStats(play_to_path_map)
+
         pbex._tqm.load_callbacks()
         pbex._tqm.send_callback(
             'start_logging',
             logger=self.options.logger,
-            username=variable_manager.extra_vars.get('ATMOUSERNAME', "No-User"),
+            username=variable_manager.extra_vars.get(
+                'ATMOUSERNAME', "No-User"),
         )
-        # END CUSTOM Subspace injection
+        # END CUSTOM Subspace injection -- We rely on our ansible-magic to take it from here..
 
         results = pbex.run()
-        # BEGIN CUSTOM Subspace injection
-        stats = pbex._tqm._stats
-        self.stats = stats
-        # Nonpersistent fact cache stores 'register' variables. We would like
-        # to get access to stdout/stderr for specific commands and relay
-        # some of that information back to the end user.
-        self.results = dict(pbex._variable_manager._nonpersistent_fact_cache)
+
+        # BEGIN CUSTOM Subspace injection -- Post-playbook execution hook
+        self._store_playbook_results(pbex)
         # End CUSTOM Subspace injection
 
         if isinstance(results, list):
@@ -322,123 +240,3 @@ class PlaybookShell(PlaybookCLI):
             return 0
         else:
             return results
-
-    # CUSTOM subspace functions below this line
-    def _get_playbook_name(self, playbook):
-        key_name = ''
-        with open(playbook,'r') as the_file:
-            for line in the_file.readlines():
-                if 'name:' in line.strip():
-                    # This is the name you will find in stats.
-                    key_name = line.replace('name:','').replace('- ','').strip()
-        if not key_name:
-            raise Exception(
-                "Unnamed playbooks will not allow CustomSubspaceStats to work properly.")
-        return key_name
-
-    def _get_playbook_map(self):
-        """
-        """
-        playbook_map = {
-            self._get_playbook_name(playbook): playbook
-            for playbook in self.args}
-        if len(playbook_map) != len(self.args):
-            raise ValueError("Non unique names in your playbooks will not allow CustomSubspaceStats to work properly. %s" % self.args)
-        return playbook_map
-
-
-# For compatability
-class Runner(PlaybookShell):
-
-    @staticmethod
-    def _convert_extra_vars_to_option(extra_vars_dict={}):
-        """
-        Because we are 'mocking a CLI', we need to convert:
-        {...} --> ['{...}']
-
-        This will allow `_play_prereqs` to handle the code
-        as it would if passed from the command-line.
-        After `_play_prereqs` has parsed the JSON/YAML option,
-        `variable_manager.extra_args` will again return the {...} structure.
-        """
-        extra_vars_option = [json.dumps(extra_vars_dict)]
-        return extra_vars_option
-
-    @classmethod
-    def _get_playbook_args(cls, playbook_path, limit_playbooks):
-        """
-        Walk the directory, return an ordered list of playbook objects.
-        If 'limit_playbooks' is included, only return matching playbooks within the directory.
-        """
-        if not isinstance(playbook_path, basestring):
-            raise TypeError(
-                "Expected 'playbook_path' as string,"
-                " received %s" % type(playbook_path))
-        # Convert file path to list of playbooks:
-        if not os.path.exists(playbook_path):
-            raise ValueError("Could not find path: %s" % (playbook_path,))
-
-        if os.path.isdir(playbook_path):
-            playbook_list = cls._get_playbook_files(
-                playbook_path, limit_playbooks)
-        else:
-            playbook_list = [playbook_path]
-        return playbook_list
-
-    @classmethod
-    def _get_playbook_files(cls, playbook_dir, limit=[]):
-        """
-        Walk the Directory structure and return an ordered list of
-        playbook objects.
-
-        :directory: The directory to walk and search for playbooks.
-        Notes: * Playbook files are identified as ending in .yml
-        """
-        return [pb for pb in cls._get_files(playbook_dir)
-                if not limit or pb.split('/')[-1] in limit]
-
-    @classmethod
-    def _get_files(cls, directory):
-        """
-        Walk the directory and retrieve each yml file.
-        """
-        files = []
-        directories = list(os.walk(directory))
-        directories.sort(cmp=operator.lt)
-        for d in directories:
-            a_dir = d[0]
-            files_in_dir = d[2]
-            files_in_dir.sort()
-            if os.path.isdir(a_dir) and "playbooks" in a_dir:
-                for f in files_in_dir:
-                    if os.path.splitext(f)[1] == ".yml":
-                        files.append(os.path.join(a_dir, f))
-        return files
-
-    @classmethod
-    def factory(
-            cls, playbook_path,
-            limit_hosts=None, limit_playbooks=None,
-            extra_vars={},
-            **runner_options):
-        """
-        Walk the Directory structure and return an ordered list of
-        playbook objects.
-
-        :playbook_path: The directory/path to use for playbook list.
-        :runner_options: These keyword args will be passed into Runner
-
-        Notes: * Playbook files are identified as ending in .yml
-               * Playbooks are not executed until calling Runner.run()
-        """
-
-        extra_vars_option = cls._convert_extra_vars_to_option(extra_vars)
-
-        args = cls._get_playbook_args(playbook_path, limit_playbooks)
-        runner = Runner(
-            args,
-            playbook_dir=playbook_path,
-            extra_vars=extra_vars_option,
-            **runner_options
-        )
-        return runner


### PR DESCRIPTION
## Solution: Update subspace to work with ansible 2.4

### Highlight Reel:
- Updated requirements.txt to point to 2.4.2.0 (beta3)
- Re-factored the code structure to more clearly define
  where the subspace touch-points are with ansible.
    - Hopefully, this will make future updates easier.
- Update strategy file to use ansible 2.4
  - We should always refer to 'variable_manager.extra_vars' when reading
    variables
- The 'option' extra_vars should be a _list_ of _string values_.
  - When using a dictionary, we must:
    1. convert to JSON-encoded string
    2. wrap string in a list.
  - After `_play_prereqs` has been executed, `extra_vars` can be found
  in `self.variable_manager`.